### PR TITLE
feat: Add Macroable Trait to JSON Driver and BaseDriver

### DIFF
--- a/src/BaseDriver.php
+++ b/src/BaseDriver.php
@@ -5,9 +5,12 @@ namespace DNT\Setting;
 use DNT\Setting\Contracts\Setting as Contract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\Macroable;
 
 abstract class BaseDriver implements Contract
 {
+    use Macroable;
+
     protected Config $config;
 
     /**

--- a/src/Drivers/Json.php
+++ b/src/Drivers/Json.php
@@ -8,10 +8,13 @@ use DNT\Setting\Exceptions\SaveSettingException;
 use DNT\Setting\Exceptions\UnreadableException;
 use DNT\Setting\Exceptions\UnwritableException;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Traits\Macroable;
 use Throwable;
 
 class Json extends BaseDriver
 {
+    use Macroable;
+
     /**
      * @inheritDoc
      */


### PR DESCRIPTION
This pull request adds the Macroable trait to the JSON driver and BaseDriver classes in the Setting for Laravel package. The Macroable trait is a convenient feature provided by Laravel that allows users to dynamically add custom methods to classes at runtime.

By adding the Macroable trait to the JSON driver and BaseDriver classes, we enable users to extend these classes with their own custom methods, providing flexibility and customization options for handling settings and drivers.